### PR TITLE
Update `install_ROOT` to Use Latest ROOT Installation Method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidp_tools"
-version = "1.0.0"
+version = "1.1.0b1"
 authors = [
     { name="Richard Dube", email="richardddube@gmail.com"},
 ]
 description = "A collection of visualization and analysis tools for particle identification"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/src/pidp_tools/analysis.py
+++ b/src/pidp_tools/analysis.py
@@ -20,10 +20,10 @@ def install_ROOT():
     import ROOT
   except:
     try:
-      subprocess.run(["wget","-q","https://github.com/MohamedElashri/ROOT/releases/download/ubuntu/root_v6.28.04_Ubuntu_20.04.zip"])
-      subprocess.run(["unzip", "-o", "-qq", "/content/root_v6.28.04_Ubuntu_20.04.zip"])
-      subprocess.run(["apt-get", "-qq", "install", "git", "dpkg-dev", "cmake", "g++", "gcc", "binutils", "libx11-dev", "libxpm-dev", "libxft-dev", "libxext-dev", "tar", "gfortran", "subversion", "&>", "/dev/null", "2>&1"])
-      subprocess.run(["rm", "-f", "root_v6.28.04_Ubuntu_20.04.zip"])
+      subprocess.run(["wget","-q","https://github.com/MohamedElashri/ROOT/releases/download/v6.30.04_python11/root_v6.30.04_Ubuntu_Python3.11.zip"])
+      subprocess.run(["unzip", "-q", "-o", "root_v6.30.04_Ubuntu_Python3.11.zip"])
+      subprocess.run(["apt-get", "-qq", "install", "git", "dpkg-dev", "cmake", "g++", "gcc", "binutils", "libx11-dev", "libxpm-dev", "libxft-dev", "libxext-dev", "tar", "gfortran", "subversion", "libpython3.11-dev", "&>", "/dev/null", "2>&1"])
+      subprocess.run(["rm", "-f", "root_v6.30.04_Ubuntu_Python3.11.zip"])
       subprocess.run(["wget", "-q", "http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb"])
       subprocess.run(["sudo", "dpkg", "-i", "libssl1.1_1.1.1f-1ubuntu2_amd64.deb"])
       subprocess.run(["rm", "-f", "libssl1.1_1.1.1f-1ubuntu2_amd64.deb"])
@@ -37,7 +37,7 @@ def install_ROOT():
       ctypes.cdll.LoadLibrary('/content/root_build/lib//libThread.so')
       ctypes.cdll.LoadLibrary('/content/root_build/lib//libTreePlayer.so')
     except:
-      raise OSError("Unable to install ROOT. This install was designed specifically for use in google colab. Installing on personal computers is discouraged due to the file size.")
+      raise OSError("Unable to install ROOT. This install was designed specifically for use in Google Colab. Installing on personal computers is discouraged due to the file size.")
 
 def get_charge(ptype):
   """


### PR DESCRIPTION
First, thanks for your great work on the [Particle Identification Playground](https://duberii.github.io/pid-playground/)! I noticed that `install_ROOT` still uses an older method I implemented two years ago for installing ROOT on Colab. However, this method no longer works because Colab has moved from Python 3.10 to Python 3.11, breaking compatibility with the old ROOT installation.  

I’ve updated `install_ROOT` with a new installation method that downloads the latest pre-built `ROOT v6.30.04` package, ensuring compatibility with Python 3.11. The function structure remains the same, maintaining error handling and library loading while streamlining the installation process.  

Tested successfully in Colab. Let me know if any further changes are needed! 